### PR TITLE
Implement calculateRisk helper

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -103,6 +103,13 @@ This structure makes filenames self-explanatory and sortable.
 ⚠️ Warning: Events are lost when the bot restarts. Consider persistent storage for production environments.
 
 ────────────────────────────────────────────
+⚙️ RISK SCORING
+
+The scanner returns scores for `hentai`, `porn`, and `sexy`. The helper
+`calculateRisk(scores)` parses these values with `parseFloat` and sums them to
+produce a single risk number.
+
+────────────────────────────────────────────
 📤 POTENTIAL EXTENSIONS
 
 - Store event history as JSON archive  

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ An automated Discord bot for moderating image content. It detects NSFW content a
 
 - Automatic scanning of all images and links
 - Risk evaluation via API (Risk Score + Tags)
+- Risk score sums hentai, porn and sexy via `calculateRisk`
 - Moderator alerts for suspicious content
 - Moderation via emoji: 👍 👎 ❌ ⚠️
 - Event system for image competitions

--- a/lib/handleMessageCreate.js
+++ b/lib/handleMessageCreate.js
@@ -9,6 +9,7 @@ const { getFilters }         = require('./filterManager');
 const { isRecentlyScanned, markScanned } = require('./scanCache');
 const { logModReview }       = require('./modLogger');
 const { saveFlaggedReviews } = require('./flaggedStore');
+const { calculateRisk } = require('./riskUtils');
 
 const PREFIX = '!';
 
@@ -61,7 +62,7 @@ async function handleScan(item, message, client) {
     const m0 = matches(0), m1 = matches(1), m2 = matches(2);
 
     const nsfwScores = data.modules?.nsfw_scanner?.scores || {};
-    const risk = (nsfwScores.hentai || 0) + (nsfwScores.porn || 0) + (nsfwScores.sexy || 0);
+    const risk = calculateRisk(nsfwScores);
 
     const tagList = highlight(tags, [...m0, ...m1, ...m2]);
 

--- a/lib/publicScanHandler.js
+++ b/lib/publicScanHandler.js
@@ -3,6 +3,7 @@ const { scanImage }       = require('./scan');
 const { evaluateTags }    = require('./scannerFilter');
 const { extractTags }     = require('./tagUtils');
 const { isRecentlyScanned, markScanned } = require('./scanCache');
+const { calculateRisk } = require('./riskUtils');
 
 function alreadyScannedPublic(messageId) {
   const key = `public:${messageId}`;
@@ -14,7 +15,7 @@ function alreadyScannedPublic(messageId) {
 function extractRisk(data) {
   const scores = data.modules?.nsfw_scanner?.scores;
   if (!scores || typeof scores !== 'object') return 0;
-  return (scores.hentai || 0) + (scores.porn || 0) + (scores.sexy || 0);
+  return calculateRisk(scores);
 }
 
 function formatDisplay(level, matched, tags, risk, message, client) {

--- a/lib/riskUtils.js
+++ b/lib/riskUtils.js
@@ -1,0 +1,8 @@
+function calculateRisk(scores = {}) {
+  const hentai = parseFloat(scores.hentai) || 0;
+  const porn   = parseFloat(scores.porn) || 0;
+  const sexy   = parseFloat(scores.sexy) || 0;
+  return hentai + porn + sexy;
+}
+
+module.exports = { calculateRisk };


### PR DESCRIPTION
## Summary
- add `calculateRisk` helper in `lib/`
- use the helper in message scanning modules
- document risk scoring in README and AGENTS.md

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685b0cba3aa883338d46868ca17d4188