### PR TITLE
feat: rebuild pixai bot with modular architecture

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,12 @@ npm-debug.log*
 logs/
 *.log
 
+bot/node_modules/
+bot/config/bot-config.json
+bot/data/
+
+docs/**/*.pdf
+
 event_files/
 deleted/
 temp/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,9 +1,7 @@
-# PixAI Discord Bot – Fresh Development Instructions
+# PixAI Discord Bot – Entwicklungsleitfaden
 
-This repository is being rebooted. The entire legacy implementation now lives in [`_archived/`](./_archived/). Use the guidance below when making changes:
-
-- ✅ Focus new development at the repository root (outside `_archived/`).
-- 🚫 Do **not** modify or delete files inside `_archived/` unless the task explicitly permits it.
-- 📝 Keep this file and the root `README.md` updated with any high-level decisions or structural changes introduced during the rebuild.
-
-If you need historical context, browse the materials in `_archived/` but leave them unchanged.
+- ✅ Neue Implementierung lebt unter [`bot/`](./bot/). Alle Änderungen für den aktiven Bot passieren dort.
+- 📁 Die Legacy-Fassung bleibt in [`_archived/`](./_archived/) und ist nur Referenz – keine Änderungen ohne ausdrückliche Aufgabe.
+- 🧾 Dokumentation pflegen: Diese Datei und die README-Dateien müssen bei Strukturänderungen aktualisiert werden.
+- 🔐 Sensible Dateien (`bot/config/bot-config.json`, `bot/data/`) gehören nicht in Git. Prüfe vor Commits die `.gitignore`.
+- 🧪 Tests werden aktuell nicht automatisch ausgeführt; stelle sicher, dass Code syntaktisch valide ist.

--- a/README.md
+++ b/README.md
@@ -1,19 +1,176 @@
-# PixAI Discord Bot – Fresh Start
+# PixAI Discord Bot
 
-The previous iteration of the PixAI Discord bot has been moved into [`_archived/`](./_archived/) so that development can begin on a brand new bot implementation.
+Ein modularer Discord-Bot für die PixAI-Community. Er verbindet Moderations- und Eventfunktionen mit einem externen Scanner-Dienst, der Bilder und Videos auf kritische Inhalte prüft. Die neue Architektur trennt Bot-Logik und Scanner vollständig und erlaubt die parallele Verwaltung mehrerer Discord-Guilds.
 
-## Repository Layout
+## Projektüberblick
 
-- `_archived/` – contains the full source code and documentation for the legacy PixAI Discord bot. Treat it as read-only unless explicitly instructed otherwise.
-- *(to be added)* – new bot source files will live at the repository root as the rebuild progresses.
+- **Bot-Kern**: Läuft auf Node.js (discord.js v14) im Verzeichnis [`bot/`](./bot/).
+- **Scanner-Integration**: Kapselt alle HTTP-Aufrufe in `lib/scannerClient.js` und kann später an eine echte API angepasst werden.
+- **Event-Management**: `lib/eventStore.js` verwaltet Uploads, Votes und Statistiken pro Kanal.
+- **Moderationsdaten**: `lib/flaggedStore.js` speichert zur Nachverfolgung alle geprüften und markierten Nachrichten.
+- **Dokumentation**: Aktuelle Guides liegen unter [`docs/`](./docs/).
 
-## Getting Started
+Der bisherige Legacy-Code ist weiterhin unter [`_archived/`](./_archived/) verfügbar, bleibt jedoch unverändert.
 
-1. Review the legacy implementation under `_archived/` if you need context or to port functionality.
-2. Implement the new bot in the root of the repository, keeping `_archived/` untouched.
-3. Update this README as new components are added to the fresh implementation.
+## Verzeichnisstruktur
 
-## Contribution Guidelines
+```
+README.md
+AGENTS.md
+bot/
+  package.json
+  index.js
+  config/
+    bot-config.example.json
+  commands/
+  events/
+  lib/
+  data/
+    events/
+    deleted/
+    logs/
+docs/
+  README.md
+  AGENTS.md
+_archived/
+```
 
-- Do not modify files under `_archived/` unless specifically asked.
-- Document new features and decisions in this README so future contributors have up-to-date guidance.
+### Ordner im Detail
+
+- `bot/commands/` – ein Modul pro Textbefehl (Eventstart, Export, Scan-Konfiguration usw.).
+- `bot/events/` – Discord-Eventlistener (`ready`, `messageCreate`, `messageReaction*`).
+- `bot/lib/` – Hilfsbibliotheken: Scanner-Client, Config-Lader, Event-/Flagged-Stores, Logging, Berechtigungen.
+- `bot/data/` – Arbeitsdaten des Bots (Events, Logs, gelöschte Uploads). Wird zur Laufzeit erstellt und nicht versioniert.
+- `docs/` – Technische und organisatorische Dokumentation für Team und Operator:innen.
+
+## Voraussetzungen
+
+- Node.js **18.18.0** oder neuer.
+- Discord-Bot-Token mit aktivierten Message Content Intents.
+- Erreichbarer HTTP-Endpunkt für den externen Scanner (oder Platzhalter während der Entwicklung).
+
+## Installation
+
+1. Repository klonen oder aktualisieren.
+2. In das Bot-Verzeichnis wechseln und Abhängigkeiten installieren:
+   ```bash
+   cd bot
+   npm install
+   ```
+3. Konfigurationsdatei erstellen:
+   - `bot/config/bot-config.json` aus `bot-config.example.json` kopieren.
+   - Felder anpassen (siehe unten). **Diese Datei darf nicht eingecheckt werden.**
+
+## Konfiguration (`bot-config.json`)
+
+```jsonc
+{
+  "bot": {
+    "token": "DISCORD_BOT_TOKEN",
+    "prefix": "!",
+    "owners": ["123456789012345678"],
+    "defaultGuild": {
+      "modRoles": [],
+      "adminRoles": [],
+      "commandChannelIds": [],
+      "event": {
+        "enabled": true,
+        "defaultDurationHours": 24,
+        "maxEntriesPerUser": 3,
+        "archiveAfterStop": true
+      },
+      "scan": {
+        "enabled": true,
+        "flagThreshold": 0.6,
+        "deleteThreshold": 0.95,
+        "reviewChannelId": null
+      }
+    }
+  },
+  "scanner": {
+    "baseUrl": "https://scanner.example.com",
+    "email": "bot@example.com",
+    "clientId": "pixai-bot",
+    "timeoutMs": 10000
+  },
+  "guilds": {
+    "GUILD_ID": {
+      "modChannelId": "123",
+      "logChannelId": "456",
+      "modRoles": ["789"],
+      "adminRoles": ["101112"],
+      "scan": {
+        "enabled": true,
+        "flagThreshold": 0.7,
+        "deleteThreshold": 0.92,
+        "reviewChannelId": "987654321"
+      },
+      "event": {
+        "enabled": true,
+        "defaultDurationHours": 24,
+        "maxEntriesPerUser": 3,
+        "voteEmojis": {
+          "approve": "👍",
+          "reject": "👎",
+          "warn": "⚠️",
+          "remove": "❌"
+        }
+      }
+    }
+  }
+}
+```
+
+### Pflichtfelder
+
+- `bot.token` – Discord-Bot-Token.
+- `scanner.baseUrl`, `scanner.email`, `scanner.clientId` – Zugangsdaten zum externen Scanner.
+- Pro Guild: `modChannelId`, `logChannelId` sowie passende Rollen-IDs für Admins und Moderation.
+
+### Mehrere Guilds
+
+`guilds` enthält je einen Schlüssel pro Guild-ID. Nicht gesetzte Werte fallen automatisch auf `bot.defaultGuild` zurück.
+
+## Betrieb
+
+- Bot starten:
+  ```bash
+  cd bot
+  npm start
+  ```
+- Beim Start lädt `index.js` automatisch alle Commands und Events und verifiziert die Guild-Konfiguration.
+- Scanner-Aufrufe laufen ausschließlich über `lib/scannerClient.js`. Bei fehlender Verbindung protokolliert der Bot Fehler, stürzt aber nicht ab.
+
+## Wichtige Commands
+
+| Befehl            | Berechtigung | Beschreibung |
+|-------------------|--------------|--------------|
+| `!eventstart`     | Admin        | Startet ein Event im aktuellen Kanal. |
+| `!eventstop`      | Admin        | Stoppt das laufende Event und schreibt Statistiken. |
+| `!eventextend`    | Admin        | Verlängert/verkürzt das Event um X Stunden. |
+| `!eventstatus`    | Mod          | Zeigt aktive Events des Servers an. |
+| `!eventexport`    | Admin        | Erstellt eine ZIP-Datei mit Event-Uploads. |
+| `!setscan`        | Admin        | Aktualisiert Flag-/Delete-Schwellenwerte pro Guild. |
+
+## Event- und Reaktionslogik
+
+- `messageCreate` trennt Befehle (Prefix) von normalen Nachrichten.
+- Uploads mit unterstützten Dateitypen werden – sofern konfiguriert – sofort zum Scanner gesendet.
+- Bei laufenden Events registriert der `eventStore` jeden Upload, inklusive Scan-Ergebnis.
+- `messageReactionAdd`/`Remove` synchronisieren Emojis mit dem `eventStore` und aktualisieren Flag-Status in `flaggedStore`.
+
+## Sicherheit & Datenschutz
+
+- Bot-Token und Scanner-Credentials gehören ausschließlich in `bot-config.json` und dürfen nicht geteilt werden.
+- Logs liegen unter `bot/data/logs/` und enthalten Moderationsereignisse. Zugriff beschränken!
+- Geflaggte Inhalte werden lokal in `bot/data/flagged.json` gespeichert und sollten regelmäßig überprüft sowie nach Abschluss eines Falls gelöscht werden.
+- Scanner-Ergebnisse können sensible Tags enthalten (NSFW, Gewalt). Stelle sicher, dass nur autorisierte Personen Zugriff auf Mod-/Log-Kanäle haben.
+
+## Weiterführende Dokumentation
+
+- Ausführliche technische Details, Rollenbeschreibungen und Prozessdokumentation: [`docs/README.md`](./docs/README.md)
+- Rollen- und Agentenmodell: [`docs/AGENTS.md`](./docs/AGENTS.md)
+
+## Legacy-Code
+
+Die ursprüngliche Implementierung inklusive weiterer Referenzen verbleibt unverändert in [`_archived/`](./_archived/). Änderungen sind dort nur auf ausdrückliche Anweisung erlaubt.

--- a/bot/commands/event-export.js
+++ b/bot/commands/event-export.js
@@ -1,0 +1,57 @@
+const path = require('path');
+const fs = require('fs');
+const AdmZip = require('adm-zip');
+
+module.exports = {
+  name: 'eventexport',
+  description: 'Exportiert Uploads des aktuellen Events als ZIP-Datei.',
+  requiredPermissions: ['ADMIN'],
+  usage: '!eventexport [topN]',
+  async execute(message, args, client) {
+    const event = client.eventStore.getEvent(message.channelId);
+    if (!event) {
+      await message.reply('In diesem Kanal läuft kein Event.');
+      return;
+    }
+    const limit = Number.parseInt(args[0] || '0', 10);
+    const uploads = Array.from(event.uploads.values());
+    if (uploads.length === 0) {
+      await message.reply('Es wurden keine Uploads gefunden.');
+      return;
+    }
+    uploads.sort((a, b) => {
+      const scoreA = (a.votes.approve.size || 0) - (a.votes.reject.size || 0);
+      const scoreB = (b.votes.approve.size || 0) - (b.votes.reject.size || 0);
+      return scoreB - scoreA;
+    });
+    const selected = limit > 0 ? uploads.slice(0, limit) : uploads;
+    const zip = new AdmZip();
+
+    for (const upload of selected) {
+      for (const attachment of upload.attachments) {
+        try {
+          const response = await fetch(attachment.url, { signal: AbortSignal.timeout(20000) });
+          if (!response.ok) {
+            client.logger.warn('Konnte Attachment nicht herunterladen', { status: response.status, url: attachment.url });
+            continue;
+          }
+          const buffer = Buffer.from(await response.arrayBuffer());
+          const filename = `${event.name}_${upload.userId}_${upload.messageId}_${attachment.name}`;
+          zip.addFile(filename, buffer);
+        } catch (error) {
+          client.logger.error('Fehler beim Download für ZIP-Export', { error: error.message });
+        }
+      }
+    }
+
+    const outDir = event.directory;
+    fs.mkdirSync(outDir, { recursive: true });
+    const zipPath = path.join(outDir, `${event.name}_${Date.now()}.zip`);
+    zip.writeZip(zipPath);
+
+    await message.reply({
+      content: `Event-Export für **${event.name}** (${selected.length} Uploads).`,
+      files: [{ attachment: zip.toBuffer(), name: path.basename(zipPath) }]
+    });
+  }
+};

--- a/bot/commands/event-extend.js
+++ b/bot/commands/event-extend.js
@@ -1,0 +1,25 @@
+module.exports = {
+  name: 'eventextend',
+  description: 'Verlängert oder verkürzt das aktuelle Event.',
+  requiredPermissions: ['ADMIN'],
+  usage: '!eventextend <+/-stunden>',
+  async execute(message, args, client) {
+    const value = args[0];
+    if (!value || !/^[-+]?\d+$/.test(value)) {
+      await message.reply('Bitte gib eine Ganzzahl an, z. B. `+2` oder `-1`.');
+      return;
+    }
+    const hours = Number.parseInt(value, 10);
+    const event = client.eventStore.updateEvent(message.channelId, (evt) => {
+      const currentEnd = evt.endsAt ? new Date(evt.endsAt).getTime() : Date.now();
+      const updated = new Date(currentEnd + hours * 3600 * 1000);
+      evt.endsAt = updated.toISOString();
+    });
+    if (!event) {
+      await message.reply('In diesem Kanal läuft kein Event.');
+      return;
+    }
+    client.activeEvents.set(message.channelId, event);
+    await message.reply(`Event **${event.name}** endet nun am ${event.endsAt}.`);
+  }
+};

--- a/bot/commands/event-start.js
+++ b/bot/commands/event-start.js
@@ -1,0 +1,34 @@
+module.exports = {
+  name: 'eventstart',
+  description: 'Startet ein neues Bildevent im aktuellen Kanal.',
+  requiredPermissions: ['ADMIN'],
+  usage: '!eventstart <name> [dauer_stunden] [max_uploads]',
+  async execute(message, args, client, guildConfig) {
+    if (!guildConfig?.event?.enabled) {
+      await message.reply('Events sind für diese Guild deaktiviert.');
+      return;
+    }
+    const name = args[0];
+    if (!name) {
+      await message.reply('Bitte gib einen internen Event-Namen an.');
+      return;
+    }
+    const durationHours = Number.parseInt(args[1] ?? guildConfig.event.defaultDurationHours ?? 24, 10);
+    const maxEntries = Number.parseInt(args[2] ?? guildConfig.event.maxEntriesPerUser ?? 3, 10);
+    const endsAt = new Date(Date.now() + Math.max(durationHours, 1) * 3600 * 1000).toISOString();
+
+    try {
+      const event = client.eventStore.startEvent(message.channelId, {
+        name,
+        guildId: message.guildId,
+        createdBy: message.author.id,
+        endsAt,
+        maxEntries
+      });
+      client.activeEvents.set(message.channelId, event);
+      await message.reply(`Event **${name}** gestartet. Läuft bis ${endsAt}.`);
+    } catch (error) {
+      await message.reply(`Event konnte nicht gestartet werden: ${error.message}`);
+    }
+  }
+};

--- a/bot/commands/event-status.js
+++ b/bot/commands/event-status.js
@@ -1,0 +1,26 @@
+const { EmbedBuilder } = require('discord.js');
+
+module.exports = {
+  name: 'eventstatus',
+  description: 'Zeigt aktive Events auf dem Server an.',
+  requiredPermissions: ['MOD'],
+  usage: '!eventstatus',
+  async execute(message, args, client) {
+    const events = client.eventStore.listActiveEvents().filter((event) => event.guildId === message.guildId);
+    if (events.length === 0) {
+      await message.reply('Aktuell laufen keine Events.');
+      return;
+    }
+    const embed = new EmbedBuilder()
+      .setTitle('Aktive Events')
+      .setColor(0x5865f2)
+      .setTimestamp(new Date());
+    for (const event of events) {
+      embed.addFields({
+        name: `${event.name} – <#${event.channelId}>`,
+        value: `Uploads: **${event.uploads}** | Votes: **${event.votes}**\nEndet: ${event.endsAt || 'offen'}`
+      });
+    }
+    await message.reply({ embeds: [embed] });
+  }
+};

--- a/bot/commands/event-stop.js
+++ b/bot/commands/event-stop.js
@@ -1,0 +1,16 @@
+module.exports = {
+  name: 'eventstop',
+  description: 'Beendet das aktuelle Event in diesem Kanal.',
+  requiredPermissions: ['ADMIN'],
+  usage: '!eventstop [Grund]',
+  async execute(message, args, client) {
+    const reason = args.join(' ') || 'manuell beendet';
+    const event = client.eventStore.stopEvent(message.channelId, reason);
+    if (!event) {
+      await message.reply('In diesem Kanal läuft kein Event.');
+      return;
+    }
+    client.activeEvents.delete(message.channelId);
+    await message.reply(`Event **${event.name}** wurde beendet. Es wurden ${event.stats.uploads} Uploads registriert.`);
+  }
+};

--- a/bot/commands/scan-config.js
+++ b/bot/commands/scan-config.js
@@ -1,0 +1,46 @@
+const { saveConfig } = require('../lib/botConfig');
+
+module.exports = {
+  name: 'setscan',
+  description: 'Passt die Schwellenwerte für den Scanner an.',
+  requiredPermissions: ['ADMIN'],
+  usage: '!setscan <flagThreshold> <deleteThreshold>',
+  async execute(message, args, client, guildConfig) {
+    if (args.length < 2) {
+      await message.reply('Bitte gib zwei Schwellenwerte an, z. B. `!setscan 0.6 0.95`.');
+      return;
+    }
+    const flagThreshold = Number.parseFloat(args[0]);
+    const deleteThreshold = Number.parseFloat(args[1]);
+    if (!Number.isFinite(flagThreshold) || !Number.isFinite(deleteThreshold)) {
+      await message.reply('Ungültige Zahlenwerte.');
+      return;
+    }
+
+    const guildId = message.guildId;
+    client.config.guilds = client.config.guilds || {};
+    client.config.guilds[guildId] = client.config.guilds[guildId] || {};
+    client.config.guilds[guildId].scan = {
+      ...(client.config.guilds[guildId].scan || {}),
+      flagThreshold,
+      deleteThreshold
+    };
+
+    client.guildConfigs.set(guildId, {
+      ...guildConfig,
+      scan: {
+        ...(guildConfig.scan || {}),
+        flagThreshold,
+        deleteThreshold
+      }
+    });
+
+    try {
+      saveConfig(client.config);
+      await message.reply(`Schwellenwerte aktualisiert: Flag ${flagThreshold.toFixed(2)}, Delete ${deleteThreshold.toFixed(2)}.`);
+    } catch (error) {
+      client.logger.error('Speichern der Konfiguration fehlgeschlagen', { error: error.message });
+      await message.reply('Konfiguration konnte nicht gespeichert werden.');
+    }
+  }
+};

--- a/bot/config/bot-config.example.json
+++ b/bot/config/bot-config.example.json
@@ -1,0 +1,55 @@
+{
+  "bot": {
+    "token": "DISCORD_BOT_TOKEN",
+    "prefix": "!",
+    "owners": ["123456789012345678"],
+    "defaultGuild": {
+      "modRoles": [],
+      "adminRoles": [],
+      "commandChannelIds": [],
+      "event": {
+        "enabled": true,
+        "defaultDurationHours": 24,
+        "maxEntriesPerUser": 3,
+        "archiveAfterStop": true
+      },
+      "scan": {
+        "enabled": true,
+        "flagThreshold": 0.6,
+        "deleteThreshold": 0.95,
+        "reviewChannelId": null
+      }
+    }
+  },
+  "scanner": {
+    "baseUrl": "https://scanner.example.com",
+    "email": "bot@example.com",
+    "clientId": "pixai-bot",
+    "timeoutMs": 10000
+  },
+  "guilds": {
+    "123456789012345678": {
+      "modChannelId": "234567890123456789",
+      "logChannelId": "345678901234567890",
+      "modRoles": ["456789012345678901"],
+      "adminRoles": ["567890123456789012"],
+      "scan": {
+        "enabled": true,
+        "flagThreshold": 0.7,
+        "deleteThreshold": 0.92,
+        "reviewChannelId": "456789012345678902"
+      },
+      "event": {
+        "enabled": true,
+        "defaultDurationHours": 24,
+        "maxEntriesPerUser": 3,
+        "voteEmojis": {
+          "approve": "👍",
+          "reject": "👎",
+          "warn": "⚠️",
+          "remove": "❌"
+        }
+      }
+    }
+  }
+}

--- a/bot/docs/README.md
+++ b/bot/docs/README.md
@@ -1,0 +1,3 @@
+# Bot-interne Dokumentation
+
+Dieses Verzeichnis dient als Ablage für technische Tiefen-Dokumente (z. B. Command-Referenzen, Developer-Notizen). Aktuell sind alle relevanten Informationen in `../lib`, `../commands`, `../events` dokumentiert sowie in den Projekt-READMEs beschrieben. Ergänzungen bitte hier ablegen.

--- a/bot/events/messageCreate.js
+++ b/bot/events/messageCreate.js
@@ -1,0 +1,163 @@
+const { mergeGuildConfig } = require('../lib/botConfig');
+const { canUseCommand } = require('../lib/permissions');
+
+function isScannableAttachment(attachment) {
+  if (!attachment?.contentType) {
+    return /\.(png|jpe?g|gif|webp|mp4|mov)$/i.test(attachment.name || '');
+  }
+  return attachment.contentType.startsWith('image/') || attachment.contentType.startsWith('video/');
+}
+
+function parseScanResult(result) {
+  if (!result || !result.ok) {
+    return { status: 'error', flagged: false, remove: false, risk: 0, tags: [], raw: result?.data ?? null };
+  }
+  const data = result.data || {};
+  const scores = data.scores || data.score || {};
+  let risk = Number.isFinite(data.risk) ? data.risk : 0;
+  if (!risk && typeof scores === 'object') {
+    for (const value of Object.values(scores)) {
+      const numeric = Number.parseFloat(value);
+      if (!Number.isNaN(numeric)) {
+        risk += numeric;
+      }
+    }
+  }
+  const tags = Array.isArray(data.tags) ? data.tags : [];
+  return {
+    status: 'ok',
+    flagged: Boolean(data.flagged ?? risk > 0),
+    remove: Boolean(data.delete ?? false),
+    risk,
+    tags,
+    raw: data
+  };
+}
+
+async function executeCommand(message, args, client, guildConfig, command) {
+  try {
+    await command.execute(message, args, client, guildConfig);
+  } catch (error) {
+    client.logger.error('Fehler beim Ausführen eines Commands', {
+      command: command.name,
+      error: error.message
+    });
+    await message.reply('Beim Ausführen des Befehls ist ein Fehler aufgetreten.');
+  }
+}
+
+async function scanAttachments(message, attachments, client, guildConfig) {
+  const results = [];
+  for (const attachment of attachments) {
+    try {
+      const response = await fetch(attachment.url, {
+        signal: AbortSignal.timeout(15000)
+      });
+      if (!response.ok) {
+        client.logger.warn('Attachment konnte nicht geladen werden', { status: response.status, url: attachment.url });
+        continue;
+      }
+      const buffer = Buffer.from(await response.arrayBuffer());
+      const scanResult = await client.scanner.scanImage(buffer, attachment.name, attachment.contentType);
+      const parsed = parseScanResult(scanResult);
+      results.push({ attachment, scan: parsed });
+      if (!guildConfig?.scan?.enabled) continue;
+      const risk = parsed.risk;
+      const flagThreshold = guildConfig.scan.flagThreshold ?? Number.POSITIVE_INFINITY;
+      const deleteThreshold = guildConfig.scan.deleteThreshold ?? Number.POSITIVE_INFINITY;
+      if (risk >= deleteThreshold) {
+        client.flaggedStore.upsert({
+          messageId: message.id,
+          guildId: message.guildId,
+          channelId: message.channelId,
+          userId: message.author.id,
+          status: 'delete',
+          risk,
+          attachment: attachment.url,
+          tags: parsed.tags
+        });
+        client.logger.warn('Upload überschreitet Delete-Threshold', { messageId: message.id, risk });
+      } else if (risk >= flagThreshold) {
+        client.flaggedStore.upsert({
+          messageId: message.id,
+          guildId: message.guildId,
+          channelId: message.channelId,
+          userId: message.author.id,
+          status: 'flag',
+          risk,
+          attachment: attachment.url,
+          tags: parsed.tags
+        });
+        client.logger.info('Upload markiert zur Moderation', { messageId: message.id, risk });
+      }
+    } catch (error) {
+      client.logger.error('Fehler beim Scannen eines Attachments', { error: error.message });
+    }
+  }
+  return results;
+}
+
+module.exports = {
+  name: 'messageCreate',
+  async execute(message, client) {
+    if (message.author.bot) return;
+
+    const prefix = client.config.bot.prefix || '!';
+    if (message.content.startsWith(prefix)) {
+      const raw = message.content.slice(prefix.length).trim();
+      const [commandName, ...args] = raw.split(/\s+/);
+      if (!commandName) return;
+      const command = client.commands.get(commandName.toLowerCase());
+      if (!command) return;
+      const guildConfig = message.guild
+        ? client.guildConfigs.get(message.guild.id) || mergeGuildConfig(client.config, message.guild.id)
+        : null;
+      if (message.guild && guildConfig) {
+        client.guildConfigs.set(message.guild.id, guildConfig);
+      }
+      if (!canUseCommand(message, command, client.config, guildConfig)) {
+        await message.reply('Du hast keine Berechtigung für diesen Befehl.');
+        return;
+      }
+      await executeCommand(message, args, client, guildConfig, command);
+      return;
+    }
+
+    if (!message.guild) return;
+
+    const guildConfig = client.guildConfigs.get(message.guild.id) || mergeGuildConfig(client.config, message.guild.id);
+    client.guildConfigs.set(message.guild.id, guildConfig);
+
+    const scannableAttachments = Array.from(message.attachments.values()).filter(isScannableAttachment);
+    let scanResults = [];
+    if (guildConfig?.scan?.enabled && scannableAttachments.length > 0 && client.scanner.isEnabled()) {
+      scanResults = await scanAttachments(message, scannableAttachments, client, guildConfig);
+    }
+
+    if (client.eventStore.isEventChannel(message.channelId) && scannableAttachments.length > 0) {
+      try {
+        const attachmentsMeta = scannableAttachments.map((attachment) => ({
+          name: attachment.name,
+          url: attachment.url,
+          size: attachment.size,
+          contentType: attachment.contentType
+        }));
+        const scanMeta = scanResults.length > 0 ? {
+          flagged: scanResults.some((entry) => entry.scan.remove || entry.scan.risk >= (guildConfig.scan?.flagThreshold ?? Infinity)),
+          delete: scanResults.some((entry) => entry.scan.remove || entry.scan.risk >= (guildConfig.scan?.deleteThreshold ?? Infinity)),
+          results: scanResults.map((entry) => ({
+            attachment: entry.attachment.name,
+            risk: entry.scan.risk,
+            tags: entry.scan.tags,
+            status: entry.scan.status
+          }))
+        } : null;
+        const event = client.eventStore.registerUpload(message, attachmentsMeta, { scan: scanMeta });
+        client.activeEvents.set(message.channelId, event);
+      } catch (error) {
+        client.logger.warn('Event Upload konnte nicht registriert werden', { error: error.message });
+        await message.reply(error.message);
+      }
+    }
+  }
+};

--- a/bot/events/messageReactionAdd.js
+++ b/bot/events/messageReactionAdd.js
@@ -1,0 +1,63 @@
+const { mergeGuildConfig } = require('../lib/botConfig');
+
+function resolveEmojiKey(emoji, guildConfig) {
+  const voteEmojis = guildConfig?.event?.voteEmojis || {};
+  for (const [key, value] of Object.entries(voteEmojis)) {
+    if (!value) continue;
+    if (value === emoji.name || value === emoji.id) return key;
+  }
+  return null;
+}
+
+async function resolveMessage(reaction) {
+  if (reaction.message.partial) {
+    return reaction.message.fetch();
+  }
+  return reaction.message;
+}
+
+module.exports = {
+  name: 'messageReactionAdd',
+  async execute(reaction, user, client) {
+    if (user.bot) return;
+
+    if (reaction.partial) {
+      try {
+        await reaction.fetch();
+      } catch (error) {
+        client.logger.warn('Konnte Reaction nicht laden', { error: error.message });
+        return;
+      }
+    }
+
+    const message = await resolveMessage(reaction);
+    if (!message.guild) return;
+
+    const guildConfig = client.guildConfigs.get(message.guild.id) || mergeGuildConfig(client.config, message.guild.id);
+    client.guildConfigs.set(message.guild.id, guildConfig);
+    const emojiKey = resolveEmojiKey(reaction.emoji, guildConfig);
+    if (!emojiKey) return;
+
+    if (client.eventStore.isEventChannel(message.channelId)) {
+      client.eventStore.addVote(message.channelId, message.id, emojiKey, user.id);
+      client.activeEvents.set(message.channelId, client.eventStore.getEvent(message.channelId));
+      return;
+    }
+
+    const flagged = client.flaggedStore.get(message.id);
+    if (flagged) {
+      client.flaggedStore.upsert({
+        ...flagged,
+        status: emojiKey,
+        moderatorId: user.id
+      });
+      if (emojiKey === 'remove') {
+        try {
+          await message.delete();
+        } catch (error) {
+          client.logger.error('Konnte Nachricht nicht löschen', { error: error.message });
+        }
+      }
+    }
+  }
+};

--- a/bot/events/messageReactionRemove.js
+++ b/bot/events/messageReactionRemove.js
@@ -1,0 +1,55 @@
+const { mergeGuildConfig } = require('../lib/botConfig');
+
+function resolveEmojiKey(emoji, guildConfig) {
+  const voteEmojis = guildConfig?.event?.voteEmojis || {};
+  for (const [key, value] of Object.entries(voteEmojis)) {
+    if (!value) continue;
+    if (value === emoji.name || value === emoji.id) return key;
+  }
+  return null;
+}
+
+async function resolveMessage(reaction) {
+  if (reaction.message.partial) {
+    return reaction.message.fetch();
+  }
+  return reaction.message;
+}
+
+module.exports = {
+  name: 'messageReactionRemove',
+  async execute(reaction, user, client) {
+    if (user.bot) return;
+
+    if (reaction.partial) {
+      try {
+        await reaction.fetch();
+      } catch (error) {
+        client.logger.warn('Konnte Reaction nicht laden', { error: error.message });
+        return;
+      }
+    }
+
+    const message = await resolveMessage(reaction);
+    if (!message.guild) return;
+
+    const guildConfig = client.guildConfigs.get(message.guild.id) || mergeGuildConfig(client.config, message.guild.id);
+    client.guildConfigs.set(message.guild.id, guildConfig);
+    const emojiKey = resolveEmojiKey(reaction.emoji, guildConfig);
+    if (!emojiKey) return;
+
+    if (client.eventStore.isEventChannel(message.channelId)) {
+      client.eventStore.removeVote(message.channelId, message.id, emojiKey, user.id);
+      client.activeEvents.set(message.channelId, client.eventStore.getEvent(message.channelId));
+      return;
+    }
+
+    const flagged = client.flaggedStore.get(message.id);
+    if (flagged) {
+      client.flaggedStore.upsert({
+        ...flagged,
+        status: 'flag'
+      });
+    }
+  }
+};

--- a/bot/events/ready.js
+++ b/bot/events/ready.js
@@ -1,0 +1,29 @@
+module.exports = {
+  name: 'ready',
+  once: true,
+  async execute(client) {
+    client.logger.info(`Bot eingeloggt als ${client.user.tag}`);
+    const guildSummaries = client.guilds.cache.map((guild) => ({
+      id: guild.id,
+      name: guild.name,
+      memberCount: guild.memberCount
+    }));
+    client.logger.info('Verbunden mit Guilds', { guilds: guildSummaries });
+
+    for (const guild of client.guilds.cache.values()) {
+      const config = client.guildConfigs.get(guild.id);
+      if (!config) {
+        client.logger.warn('Keine spezifische Konfiguration für Guild gefunden', { guildId: guild.id });
+        continue;
+      }
+      const missing = [];
+      if (!config.modChannelId) missing.push('modChannelId');
+      if (!config.logChannelId) missing.push('logChannelId');
+      if (config.scan?.enabled && typeof config.scan.flagThreshold !== 'number') missing.push('scan.flagThreshold');
+      if (config.scan?.enabled && typeof config.scan.deleteThreshold !== 'number') missing.push('scan.deleteThreshold');
+      if (missing.length > 0) {
+        client.logger.warn('Guild-Konfiguration unvollständig', { guildId: guild.id, missing });
+      }
+    }
+  }
+};

--- a/bot/index.js
+++ b/bot/index.js
@@ -1,0 +1,97 @@
+const fs = require('fs');
+const path = require('path');
+const { Client, Collection, GatewayIntentBits, Partials } = require('discord.js');
+
+const createLogger = require('./lib/logger');
+const { loadConfig, mergeGuildConfig } = require('./lib/botConfig');
+const createEventStore = require('./lib/eventStore');
+const createFlaggedStore = require('./lib/flaggedStore');
+const createScannerClient = require('./lib/scannerClient');
+
+const logger = createLogger();
+let config;
+
+try {
+  config = loadConfig();
+  logger.info('Konfiguration geladen');
+} catch (error) {
+  logger.error('Konfiguration konnte nicht geladen werden', { error: error.message });
+  process.exit(1);
+}
+
+const client = new Client({
+  intents: [
+    GatewayIntentBits.Guilds,
+    GatewayIntentBits.GuildMessages,
+    GatewayIntentBits.MessageContent,
+    GatewayIntentBits.GuildMembers,
+    GatewayIntentBits.GuildMessageReactions
+  ],
+  partials: [Partials.Message, Partials.Channel, Partials.Reaction]
+});
+
+client.logger = logger;
+client.config = config;
+client.commands = new Collection();
+client.guildConfigs = new Map();
+client.eventStore = createEventStore(path.join(__dirname, 'data', 'events'), logger);
+client.flaggedStore = createFlaggedStore(path.join(__dirname, 'data'), logger);
+client.flaggedReviews = client.flaggedStore;
+client.scanner = createScannerClient(config.scanner || {}, logger);
+client.activeEvents = new Map();
+
+if (client.scanner.isEnabled()) {
+  logger.info('Scanner-Client aktiviert', { baseUrl: config.scanner.baseUrl });
+} else {
+  logger.warn('Scanner-Client deaktiviert. Uploads werden nicht automatisch geprüft.');
+}
+
+function loadGuildConfigs() {
+  const guildIds = Object.keys(config.guilds || {});
+  guildIds.forEach((guildId) => {
+    const guildConfig = mergeGuildConfig(config, guildId);
+    client.guildConfigs.set(guildId, guildConfig);
+  });
+  logger.info('Guild-Konfigurationen vorbereitet', { guildCount: client.guildConfigs.size });
+}
+
+function loadCommands() {
+  const commandsPath = path.join(__dirname, 'commands');
+  const files = fs.readdirSync(commandsPath).filter((file) => file.endsWith('.js'));
+  for (const file of files) {
+    const commandModule = require(path.join(commandsPath, file));
+    if (commandModule?.name && typeof commandModule.execute === 'function') {
+      client.commands.set(commandModule.name, commandModule);
+      logger.debug('Command geladen', { command: commandModule.name });
+    } else {
+      logger.warn('Command-Datei ohne gültiges Interface übersprungen', { file });
+    }
+  }
+}
+
+function loadEvents() {
+  const eventsPath = path.join(__dirname, 'events');
+  const files = fs.readdirSync(eventsPath).filter((file) => file.endsWith('.js'));
+  for (const file of files) {
+    const eventModule = require(path.join(eventsPath, file));
+    if (!eventModule?.name || typeof eventModule.execute !== 'function') {
+      logger.warn('Event-Datei ohne gültiges Interface übersprungen', { file });
+      continue;
+    }
+    if (eventModule.once) {
+      client.once(eventModule.name, (...args) => eventModule.execute(...args, client));
+    } else {
+      client.on(eventModule.name, (...args) => eventModule.execute(...args, client));
+    }
+    logger.debug('Event geladen', { event: eventModule.name });
+  }
+}
+
+loadGuildConfigs();
+loadCommands();
+loadEvents();
+
+client.login(config.bot.token).catch((error) => {
+  logger.error('Login fehlgeschlagen', { error: error.message });
+  process.exit(1);
+});

--- a/bot/lib/botConfig.js
+++ b/bot/lib/botConfig.js
@@ -1,0 +1,55 @@
+const fs = require('fs');
+const path = require('path');
+
+const CONFIG_FILENAME = 'bot-config.json';
+
+function resolveConfigPath() {
+  return path.join(__dirname, '..', 'config', CONFIG_FILENAME);
+}
+
+function loadConfig() {
+  const configPath = resolveConfigPath();
+  const raw = fs.readFileSync(configPath, 'utf-8');
+  const parsed = JSON.parse(raw);
+  if (!parsed.bot || !parsed.bot.token) {
+    throw new Error('bot-config.json: Feld "bot.token" fehlt.');
+  }
+  if (!parsed.bot.prefix) {
+    parsed.bot.prefix = '!';
+  }
+  parsed.bot.owners = Array.isArray(parsed.bot.owners) ? parsed.bot.owners : [];
+  parsed.guilds = parsed.guilds || {};
+  return parsed;
+}
+
+function saveConfig(config) {
+  const configPath = resolveConfigPath();
+  fs.writeFileSync(configPath, JSON.stringify(config, null, 2));
+}
+
+function mergeGuildConfig(baseConfig, guildId) {
+  const defaults = baseConfig.bot?.defaultGuild || {};
+  const guildConfig = baseConfig.guilds?.[guildId] || {};
+  const merged = {
+    ...defaults,
+    ...guildConfig,
+    modRoles: Array.from(new Set([...(defaults.modRoles || []), ...(guildConfig.modRoles || [])])),
+    adminRoles: Array.from(new Set([...(defaults.adminRoles || []), ...(guildConfig.adminRoles || [])])),
+    event: {
+      ...(defaults.event || {}),
+      ...(guildConfig.event || {})
+    },
+    scan: {
+      ...(defaults.scan || {}),
+      ...(guildConfig.scan || {})
+    }
+  };
+  return merged;
+}
+
+module.exports = {
+  resolveConfigPath,
+  loadConfig,
+  saveConfig,
+  mergeGuildConfig
+};

--- a/bot/lib/eventStore.js
+++ b/bot/lib/eventStore.js
@@ -1,0 +1,174 @@
+const fs = require('fs');
+const path = require('path');
+
+function ensureDir(dir) {
+  fs.mkdirSync(dir, { recursive: true });
+}
+
+function serializeEvent(event) {
+  return {
+    ...event,
+    uploads: Array.from(event.uploads.values()).map((upload) => ({
+      ...upload,
+      votes: Object.fromEntries(Object.entries(upload.votes).map(([key, set]) => [key, Array.from(set)]))
+    }))
+  };
+}
+
+function createUploadRecord(message, attachmentMeta) {
+  return {
+    messageId: message.id,
+    channelId: message.channelId,
+    guildId: message.guildId,
+    userId: message.author.id,
+    username: `${message.author.username}#${message.author.discriminator}`,
+    createdAt: message.createdAt?.toISOString?.() || new Date().toISOString(),
+    attachments: attachmentMeta,
+    votes: {
+      approve: new Set(),
+      reject: new Set(),
+      warn: new Set(),
+      remove: new Set()
+    }
+  };
+}
+
+module.exports = function createEventStore(baseDir, logger) {
+  const rootDir = baseDir || path.join(__dirname, '..', 'data', 'events');
+  ensureDir(rootDir);
+
+  const events = new Map();
+
+  function persist(event) {
+    try {
+      ensureDir(event.directory);
+      const filePath = path.join(event.directory, 'event.json');
+      fs.writeFileSync(filePath, JSON.stringify(serializeEvent(event), null, 2));
+    } catch (error) {
+      logger?.error('Event persist fehlgeschlagen', { error: error.message, event: event.name });
+    }
+  }
+
+  function startEvent(channelId, payload) {
+    if (events.has(channelId)) {
+      throw new Error('In diesem Kanal läuft bereits ein Event.');
+    }
+    const directory = path.join(rootDir, `${channelId}_${payload.name}`);
+    const event = {
+      name: payload.name,
+      channelId,
+      guildId: payload.guildId,
+      createdBy: payload.createdBy,
+      startedAt: new Date().toISOString(),
+      endsAt: payload.endsAt,
+      maxEntries: payload.maxEntries,
+      directory,
+      uploads: new Map(),
+      stats: {
+        uploads: 0,
+        flagged: 0,
+        votes: 0
+      }
+    };
+    events.set(channelId, event);
+    persist(event);
+    logger?.info('Event gestartet', { channelId, name: payload.name });
+    return event;
+  }
+
+  function stopEvent(channelId, reason) {
+    const event = events.get(channelId);
+    if (!event) return null;
+    event.stoppedAt = new Date().toISOString();
+    event.stopReason = reason;
+    persist(event);
+    events.delete(channelId);
+    logger?.info('Event gestoppt', { channelId, name: event.name, reason });
+    return event;
+  }
+
+  function getEvent(channelId) {
+    return events.get(channelId) || null;
+  }
+
+  function isEventChannel(channelId) {
+    return events.has(channelId);
+  }
+
+  function registerUpload(message, attachments, meta = {}) {
+    const event = events.get(message.channelId);
+    if (!event) return null;
+    const existing = Array.from(event.uploads.values()).filter((entry) => entry.userId === message.author.id);
+    if (event.maxEntries && existing.length >= event.maxEntries) {
+      throw new Error('Maximale Anzahl an Uploads für dieses Event erreicht.');
+    }
+    const record = createUploadRecord(message, attachments);
+    record.scan = meta.scan || null;
+    if (meta.scan?.flagged) {
+      event.stats.flagged += 1;
+    }
+    event.uploads.set(record.messageId, record);
+    event.stats.uploads = event.uploads.size;
+    persist(event);
+    logger?.info('Event Upload registriert', { channelId: message.channelId, messageId: message.id });
+    return record;
+  }
+
+  function updateVotes(channelId, messageId, emojiKey, userId, action) {
+    const event = events.get(channelId);
+    if (!event) return null;
+    const record = event.uploads.get(messageId);
+    if (!record) return null;
+    const votes = record.votes;
+    if (!votes[emojiKey]) return null;
+    if (action === 'add') {
+      votes[emojiKey].add(userId);
+      event.stats.votes += 1;
+    } else if (action === 'remove') {
+      votes[emojiKey].delete(userId);
+      event.stats.votes = Math.max(0, event.stats.votes - 1);
+    }
+    persist(event);
+    return record;
+  }
+
+  function addVote(channelId, messageId, emojiKey, userId) {
+    return updateVotes(channelId, messageId, emojiKey, userId, 'add');
+  }
+
+  function removeVote(channelId, messageId, emojiKey, userId) {
+    return updateVotes(channelId, messageId, emojiKey, userId, 'remove');
+  }
+
+  function listActiveEvents() {
+    return Array.from(events.values()).map((event) => ({
+      name: event.name,
+      channelId: event.channelId,
+      guildId: event.guildId,
+      startedAt: event.startedAt,
+      endsAt: event.endsAt,
+      uploads: event.uploads.size,
+      votes: event.stats.votes
+    }));
+  }
+
+  function updateEvent(channelId, updater) {
+    const event = events.get(channelId);
+    if (!event) return null;
+    updater(event);
+    persist(event);
+    return event;
+  }
+
+  return {
+    startEvent,
+    stopEvent,
+    registerUpload,
+    addVote,
+    removeVote,
+    getEvent,
+    isEventChannel,
+    listActiveEvents,
+    updateEvent
+  };
+};

--- a/bot/lib/flaggedStore.js
+++ b/bot/lib/flaggedStore.js
@@ -1,0 +1,72 @@
+const fs = require('fs');
+const path = require('path');
+
+const STORE_FILENAME = 'flagged.json';
+
+function readFile(filePath) {
+  try {
+    const raw = fs.readFileSync(filePath, 'utf-8');
+    return JSON.parse(raw);
+  } catch (error) {
+    if (error.code === 'ENOENT') return [];
+    throw error;
+  }
+}
+
+function writeFile(filePath, data) {
+  fs.writeFileSync(filePath, JSON.stringify(data, null, 2));
+}
+
+module.exports = function createFlaggedStore(baseDir, logger) {
+  const storeDir = baseDir || path.join(__dirname, '..', 'data');
+  const filePath = path.join(storeDir, STORE_FILENAME);
+  fs.mkdirSync(storeDir, { recursive: true });
+
+  const index = new Map();
+
+  function loadInitial() {
+    const items = readFile(filePath);
+    for (const item of items) {
+      if (item && item.messageId) {
+        index.set(item.messageId, item);
+      }
+    }
+    logger?.info('FlaggedStore geladen', { size: index.size });
+  }
+
+  function persist() {
+    writeFile(filePath, Array.from(index.values()));
+  }
+
+  function upsert(record) {
+    if (!record || !record.messageId) return null;
+    const merged = {
+      ...index.get(record.messageId),
+      ...record,
+      updatedAt: new Date().toISOString()
+    };
+    if (!merged.createdAt) {
+      merged.createdAt = new Date().toISOString();
+    }
+    index.set(record.messageId, merged);
+    persist();
+    return merged;
+  }
+
+  function remove(messageId) {
+    const existed = index.delete(messageId);
+    if (existed) persist();
+    return existed;
+  }
+
+  loadInitial();
+
+  return {
+    upsert,
+    remove,
+    get: (messageId) => index.get(messageId),
+    list: () => Array.from(index.values()),
+    size: () => index.size,
+    snapshot: () => new Map(index)
+  };
+};

--- a/bot/lib/logger.js
+++ b/bot/lib/logger.js
@@ -1,0 +1,55 @@
+const fs = require('fs');
+const path = require('path');
+
+const LEVELS = ['error', 'warn', 'info', 'debug'];
+
+function timestamp() {
+  return new Date().toISOString();
+}
+
+function normalizeLevel(level) {
+  if (!level) return 'info';
+  const idx = LEVELS.indexOf(String(level).toLowerCase());
+  return idx === -1 ? 'info' : LEVELS[idx];
+}
+
+module.exports = function createLogger(options = {}) {
+  const logLevel = normalizeLevel(options.level);
+  const logDir = options.directory || path.join(__dirname, '..', 'data', 'logs');
+  const logFile = options.file || 'bot.log';
+
+  fs.mkdirSync(logDir, { recursive: true });
+
+  const filePath = path.join(logDir, logFile);
+
+  function shouldLog(level) {
+    return LEVELS.indexOf(level) <= LEVELS.indexOf(logLevel);
+  }
+
+  function write(level, message, meta) {
+    if (!shouldLog(level)) return;
+    const payload = {
+      level,
+      time: timestamp(),
+      message,
+      ...(meta ? { meta } : {})
+    };
+    const line = JSON.stringify(payload);
+    fs.appendFile(filePath, line + '\n', () => {});
+    const fn = level === 'error' ? console.error : level === 'warn' ? console.warn : console.log;
+    fn(`[${payload.time}] [${level.toUpperCase()}] ${message}` + (meta ? ` ${JSON.stringify(meta)}` : ''));
+  }
+
+  function buildLogger(boundMeta = {}) {
+    return {
+      level: logLevel,
+      info: (msg, meta) => write('info', msg, meta ? { ...boundMeta, ...meta } : boundMeta),
+      warn: (msg, meta) => write('warn', msg, meta ? { ...boundMeta, ...meta } : boundMeta),
+      error: (msg, meta) => write('error', msg, meta ? { ...boundMeta, ...meta } : boundMeta),
+      debug: (msg, meta) => write('debug', msg, meta ? { ...boundMeta, ...meta } : boundMeta),
+      child: (childMeta = {}) => buildLogger({ ...boundMeta, ...childMeta })
+    };
+  }
+
+  return buildLogger();
+};

--- a/bot/lib/permissions.js
+++ b/bot/lib/permissions.js
@@ -1,0 +1,40 @@
+function isOwner(userId, config) {
+  return Boolean(config?.bot?.owners?.includes(userId));
+}
+
+function isGuildAdmin(member, guildConfig) {
+  if (!member) return false;
+  if (member.permissions?.has?.('Administrator')) return true;
+  const roles = guildConfig?.adminRoles || [];
+  return member.roles?.cache?.some((role) => roles.includes(role.id));
+}
+
+function hasModRole(member, guildConfig) {
+  if (!member) return false;
+  if (isGuildAdmin(member, guildConfig)) return true;
+  const roles = guildConfig?.modRoles || [];
+  return member.roles?.cache?.some((role) => roles.includes(role.id));
+}
+
+function canUseCommand(message, command, config, guildConfig) {
+  if (!command) return false;
+  if (command.allowDM && message.channel?.isDMBased?.()) return true;
+  if (isOwner(message.author.id, config)) return true;
+  if (command.requiredPermissions?.includes('ADMIN')) {
+    return isGuildAdmin(message.member, guildConfig);
+  }
+  if (command.requiredPermissions?.includes('MOD')) {
+    return hasModRole(message.member, guildConfig);
+  }
+  if (Array.isArray(command.discordPermissions) && command.discordPermissions.length > 0) {
+    return command.discordPermissions.every((perm) => message.member?.permissions?.has?.(perm));
+  }
+  return true;
+}
+
+module.exports = {
+  isOwner,
+  isGuildAdmin,
+  hasModRole,
+  canUseCommand
+};

--- a/bot/lib/scannerClient.js
+++ b/bot/lib/scannerClient.js
@@ -1,0 +1,145 @@
+const { Blob } = require('buffer');
+const { setTimeout: delay } = require('timers/promises');
+
+function buildUrl(base, pathname, params = {}) {
+  const url = new URL(pathname, base.endsWith('/') ? base : `${base}/`);
+  Object.entries(params).forEach(([key, value]) => {
+    if (value !== undefined && value !== null) {
+      url.searchParams.set(key, value);
+    }
+  });
+  return url;
+}
+
+function toJSONSafe(payload) {
+  if (payload === undefined || payload === null) return null;
+  if (typeof payload === 'object') return payload;
+  try {
+    return JSON.parse(payload);
+  } catch (error) {
+    return { raw: String(payload) };
+  }
+}
+
+module.exports = function createScannerClient(scannerConfig = {}, logger) {
+  const disabled = !scannerConfig.baseUrl;
+  let token = null;
+  let tokenExpiresAt = 0;
+  let isRenewing = false;
+
+  const clientLogger = logger?.child({ scope: 'scannerClient' });
+
+  async function ensureToken({ renew = false } = {}) {
+    if (disabled) return null;
+    if (!scannerConfig.email || !scannerConfig.clientId) {
+      throw new Error('Scanner-Konfiguration ist unvollständig (email/clientId).');
+    }
+    const now = Date.now();
+    if (!renew && token && tokenExpiresAt - 60_000 > now) {
+      return token;
+    }
+    while (isRenewing) {
+      await delay(100);
+    }
+    isRenewing = true;
+    try {
+      const url = buildUrl(scannerConfig.baseUrl, 'token', {
+        email: scannerConfig.email,
+        clientId: scannerConfig.clientId,
+        renew: renew ? '1' : undefined
+      });
+      const res = await fetch(url, {
+        method: 'GET',
+        headers: { Accept: 'application/json' },
+        signal: AbortSignal.timeout(scannerConfig.timeoutMs || 10000)
+      });
+      if (!res.ok) {
+        const text = await res.text();
+        throw new Error(`Tokenabruf fehlgeschlagen (${res.status}): ${text}`);
+      }
+      const body = await res.json();
+      token = body.token;
+      const ttl = Number(body.expiresIn || body.expires_in || 600);
+      tokenExpiresAt = Date.now() + ttl * 1000;
+      clientLogger?.info('Scanner-Token erneuert');
+      return token;
+    } finally {
+      isRenewing = false;
+    }
+  }
+
+  async function perform(pathname, options = {}, attempt = 0) {
+    if (disabled) {
+      return { ok: false, disabled: true, data: null };
+    }
+    try {
+      const authToken = await ensureToken({ renew: attempt > 0 });
+      const url = buildUrl(scannerConfig.baseUrl, pathname);
+      const headers = {
+        ...(options.headers || {}),
+        Authorization: authToken ? `Bearer ${authToken}` : undefined
+      };
+      const response = await fetch(url, {
+        ...options,
+        headers,
+        signal: AbortSignal.timeout(scannerConfig.timeoutMs || 15000)
+      });
+      if (response.status === 403 && attempt === 0) {
+        clientLogger?.warn('Scanner antwortete mit 403 – versuche Token zu erneuern');
+        await ensureToken({ renew: true });
+        return perform(pathname, options, 1);
+      }
+      const text = await response.text();
+      const data = toJSONSafe(text);
+      return { ok: response.ok, status: response.status, data };
+    } catch (error) {
+      clientLogger?.error('Scanner-Anfrage fehlgeschlagen', { error: error.message, path: pathname });
+      return { ok: false, error: error.message };
+    }
+  }
+
+  async function scanImage(buffer, filename, mimeType) {
+    if (disabled) return { ok: false, disabled: true };
+    try {
+      const formData = new FormData();
+      const blob = new Blob([buffer], { type: mimeType || 'application/octet-stream' });
+      formData.append('file', blob, filename || 'upload');
+      const result = await perform('check', {
+        method: 'POST',
+        body: formData
+      });
+      return result;
+    } catch (error) {
+      clientLogger?.error('scanImage fehlgeschlagen', { error: error.message });
+      return { ok: false, error: error.message };
+    }
+  }
+
+  async function scanBatch(buffer, mimeType) {
+    if (disabled) return { ok: false, disabled: true };
+    try {
+      const blob = new Blob([buffer], { type: mimeType || 'application/octet-stream' });
+      const result = await perform('batch', {
+        method: 'POST',
+        body: blob,
+        headers: { 'Content-Type': blob.type }
+      });
+      return result;
+    } catch (error) {
+      clientLogger?.error('scanBatch fehlgeschlagen', { error: error.message });
+      return { ok: false, error: error.message };
+    }
+  }
+
+  async function getStats() {
+    return perform('stats', { method: 'GET' });
+  }
+
+  return {
+    ensureToken,
+    scanImage,
+    scanBatch,
+    getStats,
+    isEnabled: () => !disabled
+  };
+};

--- a/bot/package.json
+++ b/bot/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "pixai-discord-bot",
+  "version": "0.1.0",
+  "description": "Moderationsbot für PixAI-Communities mit externer Scanner-Anbindung.",
+  "main": "index.js",
+  "type": "commonjs",
+  "engines": {
+    "node": ">=18.18.0"
+  },
+  "scripts": {
+    "start": "node index.js"
+  },
+  "dependencies": {
+    "adm-zip": "^0.5.10",
+    "discord.js": "^14.15.3"
+  }
+}

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -1,0 +1,95 @@
+# Agenten- & Rollenhandbuch – PixAI Discord Bot
+
+Dieses Dokument verbindet technische Module mit operativen Rollen. Es soll Entwicklern, Moderatoren und Ownern helfen, Verantwortlichkeiten klar zuzuordnen.
+
+## 1. Technische Agenten
+
+| Agent | Verantwortungsbereich | Relevante Dateien |
+|-------|-----------------------|-------------------|
+| **Bot-Core** | Startet den Discord-Client, lädt Commands & Events, hält Laufzeitdaten bereit. | `bot/index.js`, `bot/commands/`, `bot/events/` |
+| **Scanner-Client** | Kommuniziert ausschließlich über HTTP mit dem externen Scanner (Token, Checks, Stats). | `bot/lib/scannerClient.js` |
+| **Event-Manager** | Verwalten von Events, Uploads, Votes, Persistenz in JSON. | `bot/lib/eventStore.js`, Daten unter `bot/data/events/` |
+| **Moderations-Manager** | Speichert und aktualisiert geflaggte Inhalte, synchronisiert Reaction-Entscheidungen. | `bot/lib/flaggedStore.js`, `bot/events/messageReaction*.js` |
+| **Konfigurations-Manager** | Lädt & speichert `bot-config.json`, merged Guild-Defaults. | `bot/lib/botConfig.js`, `bot/commands/scan-config.js` |
+| **Logging-Agent** | Konsolidiert Logausgaben (Konsole & Datei). | `bot/lib/logger.js`, `bot/data/logs/bot.log` |
+
+### Zusammenarbeit der Agenten
+
+1. **Bot-Core** lädt Konfiguration via **Konfigurations-Manager** und initialisiert **Scanner-Client**, **Event-Manager** und **Moderations-Manager**.
+2. `messageCreate` delegiert Uploads an den **Scanner-Client** und registriert Ergebnisse beim **Event-Manager**.
+3. Reaction-Events aktualisieren Votes im **Event-Manager** und Statuswerte im **Moderations-Manager**.
+4. Alle Schritte protokolliert der **Logging-Agent**.
+
+## 2. Menschliche Rollen
+
+| Rolle | Aufgaben | Rechte/Beschränkungen | Wichtige Commands/Events |
+|-------|---------|-----------------------|-------------------------|
+| **Bot-Owner** | Technische Verantwortung, Deployment, Konfigurationspflege, Fehleranalyse. | Immer vollen Zugriff (IDs in `bot.bot.owners`). | Zugriff auf alle Commands, kann `bot-config.json` anpassen. |
+| **Server-Admins** | Setzen Guild-Konfigurationen, starten/stoppen Events, definieren Schwellenwerte. | Müssen in `adminRoles` stehen oder Discord-`ADMINISTRATOR` besitzen. | `!eventstart`, `!eventstop`, `!eventextend`, `!eventexport`, `!setscan` |
+| **Moderatoren** | Überwachen Uploads, reagieren auf Flagged Content, voten in Events. | Rollen aus `modRoles`. | `!eventstatus`, Reaction-Emojis (👍/👎/⚠️/❌) |
+| **Normale User** | Teilnehmen an Events, laden Bilder hoch. | Kein Zugriff auf Admin-/Mod-Commands, unterliegen Upload-Limits (`event.maxEntriesPerUser`). | `messageCreate` für Einreichungen, Event-Reaktionen falls erlaubt. |
+
+### Berechtigungsmatrix
+
+- Commands prüfen erst Owner-Status, dann Admin-/Mod-Rollen via `permissions.js`.
+- Reaction-Events dürfen nur echte User (keine Bots) auslösen.
+- Upload-Limits enforced durch den **Event-Manager**.
+
+## 3. Prozessketten
+
+### 3.1 Upload & Scan
+
+1. User sendet Nachricht mit Attachment.
+2. `messageCreate` erkennt scannbaren Inhalt und ruft `scannerClient.scanImage()` auf.
+3. Ergebnis wird bewertet (`flagThreshold`/`deleteThreshold`).
+4. Bei Überschreitung speichert der **Moderations-Manager** den Fall (`status: flag|delete`).
+5. Läuft ein Event, registriert der **Event-Manager** den Upload samt Scan-Metadaten.
+
+### 3.2 Moderationsentscheidung
+
+1. Moderator reagiert mit Emoji (⚠️, ❌ etc.).
+2. `messageReactionAdd` mappt Emoji → Aktion.
+3. **Event-Manager** aktualisiert Votes (falls Event-Kanal).
+4. **Moderations-Manager** aktualisiert Status (Warnung, Löschung) und entfernt ggf. die Nachricht.
+5. Entfernt ein Moderator seine Reaktion, setzt `messageReactionRemove` den Status zurück auf `flag` (zur erneuten Prüfung).
+
+### 3.3 Konfigurationsänderung
+
+1. Admin ruft `!setscan <flag> <delete>` auf.
+2. **Konfigurations-Manager** schreibt die neuen Werte in `bot-config.json`.
+3. `client.guildConfigs` wird aktualisiert; zukünftige Scans nutzen die neuen Thresholds.
+
+## 4. Kommunikations- und Datenflüsse
+
+```mermaid
+graph LR
+  A[User Upload] --> B(messageCreate)
+  B --> C{Scanner aktiv?}
+  C -- Ja --> D[scannerClient]
+  D --> E[Moderations-Manager]
+  B --> F{Event aktiv?}
+  F -- Ja --> G[Event-Manager]
+  H[Moderator Reaction] --> I(messageReactionAdd/Remove)
+  I --> G
+  I --> E
+  B --> J[Logger]
+  D --> J
+  G --> J
+  E --> J
+```
+
+## 5. Governance & Compliance
+
+- **Datensparsamkeit**: Logs und Flagged-Einträge regelmäßig prüfen und archivieren/löschen, sobald Fälle abgeschlossen sind.
+- **Zugriffsmanagement**: `bot-config.json` nur verschlüsselt ablegen; Dateirechte im Deployment einschränken.
+- **Vorfallreaktion**: Bei Scanner-Ausfällen werden Attachments protokolliert, aber nicht automatisch gelöscht. Moderation informiert Owner/Admins.
+- **Änderungsmanagement**: Neue Features nur über Pull Requests mit aktualisierter Dokumentation (`README.md`, `docs/README.md`, `docs/AGENTS.md`).
+
+## 6. Referenzen
+
+- Legacy-Architektur & zusätzliche Features: `_archived/README.md`, `_archived/DEV-README.md`.
+- Aktuelles Entwickler-Howto: [`docs/README.md`](./README.md).
+
+---
+
+Bei Fragen zur Rollenverteilung oder zum technischen Ablauf sollte dieses Dokument zuerst konsultiert werden. Ergänzungen bitte immer in Abstimmung mit Bot-Ownern einpflegen.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,136 @@
+# Dokumentation – PixAI Discord Bot
+
+## 1. Architekturüberblick
+
+Die neue Bot-Generation trennt konsequent zwischen Discord-Interaktion und Scanner-Anbindung. Kernkomponenten:
+
+- **Bot Core (`bot/index.js`)** – Initialisiert den Discord-Client, lädt Config, Commands und Events.
+- **Commands (`bot/commands/`)** – Textbasierte Moderations- und Administrationsbefehle. Jeder Befehl exportiert `{ name, description, requiredPermissions, execute }`.
+- **Events (`bot/events/`)** – Listener für `ready`, `messageCreate`, `messageReactionAdd`, `messageReactionRemove`.
+- **Libraries (`bot/lib/`)**:
+  - `botConfig.js` – Lesen/Speichern von `bot-config.json`, Mergen von Default-Guild-Werten.
+  - `scannerClient.js` – HTTP-Client für den externen Scanner (`/token`, `/check`, `/batch`, `/stats`).
+  - `eventStore.js` – Map-basierter Eventmanager inkl. JSON-Persistenz pro Event.
+  - `flaggedStore.js` – Ablage geprüfter/gefährdeter Inhalte in `bot/data/flagged.json`.
+  - `permissions.js` – Owner-/Admin-/Mod-Prüfungen.
+  - `logger.js` – Zentrales JSON-Logging (Konsole + `bot/data/logs/bot.log`).
+
+## 2. Scanner-Anbindung
+
+`scannerClient.js` kapselt alle HTTP-Aufrufe:
+
+- `ensureToken()` ruft `/token?email=...&clientId=...` ab, cached das Ergebnis und erneuert bei 403 automatisch.
+- `scanImage(buffer, filename, mime)` sendet ein Attachment via `POST /check` (Multipart).
+- `scanBatch(buffer, mime)` erlaubt den Upload mehrerer Frames oder ZIPs via `POST /batch`.
+- `getStats()` liest Statistikdaten (`GET /stats`).
+
+Zeitüberschreitungen werden über `AbortSignal.timeout` abgesichert. Netzwerkfehler erzeugen Logeinträge, ohne den Bot zu beenden.
+
+## 3. Konfiguration
+
+### 3.1 Struktur
+
+`bot-config.json` besteht aus drei Ebenen:
+
+1. `bot` – Globale Bot-Einstellungen (Token, Prefix, Owner-IDs, Default-Guild).
+2. `scanner` – Zugangsdaten zum externen Scanner (Base-URL, Service-Mail, Client-ID, Timeout).
+3. `guilds` – Individuelle Overrides pro Guild-ID (Rollen, Kanäle, Scan- & Event-Settings).
+
+Jede Guild-Konfiguration erbt automatisch Werte aus `bot.defaultGuild`. Fehlt ein Eintrag, greift der Default.
+
+### 3.2 Felder im Detail
+
+| Feld | Beschreibung |
+|------|--------------|
+| `bot.token` | Discord-Bot-Token. Muss geheim bleiben. |
+| `bot.prefix` | Prefix für Textbefehle (Standard: `!`). |
+| `bot.owners` | User-IDs mit uneingeschränktem Zugriff. |
+| `bot.defaultGuild.modRoles` | Rollen, die Moderationsrechte erhalten. |
+| `bot.defaultGuild.adminRoles` | Rollen mit Adminbefehlen. |
+| `bot.defaultGuild.event.*` | Standardwerte für Events (Aktivierung, Dauer, Upload-Limit). |
+| `bot.defaultGuild.scan.*` | Standard-Schwellen für Flag/Delete, Review-Channel. |
+| `scanner.baseUrl` | Basis-URL des Scanner-Dienstes. |
+| `scanner.email` / `scanner.clientId` | Authentifizierungsdaten für `/token`. |
+| `scanner.timeoutMs` | Timeout in Millisekunden für alle Requests. |
+| `guilds[ID].modChannelId` | Kanal für Moderationsmeldungen. |
+| `guilds[ID].logChannelId` | Kanal für Bot-Logs innerhalb der Guild. |
+| `guilds[ID].event.voteEmojis` | Zuordnung von Emojis zu den Reaktionsaktionen (`approve`, `reject`, `warn`, `remove`). |
+
+### 3.3 Secrets & Speicherung
+
+- `bot/config/bot-config.json` darf nie committed werden.
+- Zur Laufzeit aktualisierte Werte (z. B. durch `!setscan`) werden direkt in der Datei gespeichert.
+
+## 4. Datenablage
+
+- `bot/data/events/` – Ein Unterordner pro aktivem/abgeschlossenem Event (`<channelId>_<eventName>` mit `event.json` & optionalen ZIPs).
+- `bot/data/flagged.json` – JSON-Liste geflaggter Nachrichten inklusive Risiko und Tags.
+- `bot/data/deleted/` – Platzhalter für gelöschte Uploads (kann von Moderation befüllt werden).
+- `bot/data/logs/bot.log` – Strukturierte Logdatei.
+
+Alle Ordner werden automatisch erstellt und sind per `.gitignore` vom Repository ausgeschlossen.
+
+## 5. Events & Ablauf
+
+### 5.1 `ready`
+- Loggt Bot-Tag und alle Guilds.
+- Prüft pro Guild, ob Pflichtwerte gesetzt sind (`modChannelId`, `logChannelId`, Scan-Schwellen).
+
+### 5.2 `messageCreate`
+- Erkennt Commands via Prefix (`client.commands`).
+- Führt Berechtigungsprüfungen mittels `permissions.js` durch.
+- Scannt Attachments, sofern der Scanner aktiv ist und das Guild-Profil `scan.enabled` gesetzt hat.
+- Schreibt Treffer in `flaggedStore` (Status `flag` oder `delete`).
+- Registriert Event-Uploads via `eventStore.registerUpload(...)`.
+
+### 5.3 `messageReactionAdd` / `messageReactionRemove`
+- Übersetzt Emojis anhand der Guild-Konfiguration (`event.voteEmojis`).
+- Aktualisiert Votes in `eventStore`.
+- Synchronisiert Entscheidungen im `flaggedStore` (Warnung/Löschung).
+
+## 6. Commands
+
+| Name | Rolle | Zweck |
+|------|-------|-------|
+| `eventstart` | Admin | Neues Event im Kanal starten (`!eventstart <name> [stunden] [max]`). |
+| `eventstop` | Admin | Laufendes Event beenden. |
+| `eventextend` | Admin | Laufzeit um ±X Stunden anpassen. |
+| `eventstatus` | Mod | Liste aller aktiven Events des Servers. |
+| `eventexport` | Admin | ZIP der Uploads erstellen (optional top N). |
+| `setscan` | Admin | Flag-/Delete-Thresholds aktualisieren und speichern. |
+
+## 7. Rollen & Rechte
+
+Siehe ergänzend [`docs/AGENTS.md`](./AGENTS.md). Kurzfassung:
+
+- **Owner**: Immer berechtigt, Commands auszuführen.
+- **Admins**: Müssen in `adminRoles` stehen oder Discord-`ADMINISTRATOR` besitzen.
+- **Moderatoren**: Rollen aus `modRoles`. Dürfen Events einsehen und reagieren.
+- **User**: Können an Events teilnehmen; Upload-Limits werden im `eventStore` überwacht.
+
+## 8. Sicherheit & Compliance
+
+- Discord-Bot-Token und Scanner-Credentials niemals in Tickets, Logs oder Commits posten.
+- Geflaggte Inhalte enthalten sensible Medien; Zugriff auf `bot/data/` nur für Moderationspersonal.
+- Lösch- oder Warnaktionen werden durch Reaction-Emojis gesteuert. Prüfe regelmäßig, dass `voteEmojis` serverweit konsistent sind.
+- Bei Fehlern im Scanner (Timeout/403) bleibt die Moderation aktiv; die Meldung erscheint im Log.
+
+## 9. Erweiterung & Wartung
+
+- Neue Commands: Datei unter `bot/commands/` anlegen, `name` eindeutig wählen, Berechtigungen definieren.
+- Neue Events: Datei unter `bot/events/`, Export `{ name, once?, execute }`.
+- Event-Datenpersistenz kann erweitert werden (z. B. zusätzliche JSON-Exports). Nutze `eventStore.updateEvent` für Modifikationen.
+- Für Video/GIF-Handling können zusätzliche Batch-Scans über `scannerClient.scanBatch` implementiert werden (vgl. Legacy-Code in `_archived/`).
+
+## 10. Troubleshooting
+
+| Problem | Ursache | Lösung |
+|---------|---------|--------|
+| Keine Scans trotz Uploads | Scanner deaktiviert oder keine Guild-Konfiguration | Prüfen, ob `scan.enabled` true und `scanner.baseUrl` gesetzt ist. Logs unter `bot/data/logs/bot.log` prüfen. |
+| Commands reagieren nicht | Fehlende Berechtigungen oder falscher Prefix | `bot.prefix` prüfen, Rollen in `bot-config.json` anpassen. |
+| Event-Upload abgelehnt | Upload-Limit erreicht | `maxEntriesPerUser` erhöhen oder Einträge löschen. |
+| ZIP-Export fehlschlägt | Attachment nicht mehr verfügbar | Log prüfen, ggf. Export direkt nach Event-Ende durchführen. |
+
+## 11. Bezug zur Legacy-Version
+
+Das alte Projekt (`_archived/`) liefert Referenzcode für erweiterte Funktionen (Filter-Management, öffentliche Scanner-API, Video-Scans). Bei Portierungen stets prüfen, dass keine Scanner-Details außerhalb von `lib/scannerClient.js` landen.


### PR DESCRIPTION
## Summary
- create a fresh Node.js/discord.js bot structure under `bot/` with commands, events, and shared libraries
- add scanner client, event and flagged stores, and permissions handling to mirror the legacy feature set while keeping the scanner external
- document setup, configuration, and roles in updated README and new docs

## Testing
- not run (per instructions)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691701c7d7dc83338d231a0d4ecb69c5)