### PR TITLE
Align config loader with reference schema

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,5 +3,7 @@
 - ✅ Neue Implementierung lebt unter [`bot/`](./bot/). Alle Änderungen für den aktiven Bot passieren dort.
 - 📁 Die Legacy-Fassung bleibt in [`_archived/`](./_archived/) und ist nur Referenz – keine Änderungen ohne ausdrückliche Aufgabe.
 - 🧾 Dokumentation pflegen: Diese Datei und die README-Dateien müssen bei Strukturänderungen aktualisiert werden.
+- 🧭 Referenz-Mapping (`*_v1` ↔ produktive Module) ist in [`DOCU/STRUCTURE_SYNC.md`](./DOCU/STRUCTURE_SYNC.md) dokumentiert und wird durch Wrapper unter `bot/lib/*_v1.js` gespiegelt.
+- 🧩 Die Config-Ladefunktion akzeptiert sowohl Felder aus der Referenz (`bot.discordToken`, `scanner.url`) als auch die produktiven Namen; neue Pfade/Versionen werden mit Defaults ergänzt.
 - 🔐 Sensible Dateien (`bot/config/bot-config.json`, `bot/data/`) gehören nicht in Git. Prüfe vor Commits die `.gitignore`.
 - 🧪 Tests werden aktuell nicht automatisch ausgeführt; stelle sicher, dass Code syntaktisch valide ist.

--- a/DOCU/STRUCTURE_SYNC.md
+++ b/DOCU/STRUCTURE_SYNC.md
@@ -1,0 +1,55 @@
+# Strukturabgleich Referenz ↔ aktuelle Implementierung
+
+Dieses Dokument fixiert die Abbildung zwischen der versionierten Referenz aus `/docu/` und dem produktiven Bot-Code unter `bot/`.
+
+## Commands
+- `event_start_v1` → `bot/commands/eventstart.js`
+- `event_stop_v1` → `bot/commands/eventstop.js`
+- `event_stats_v1` → `bot/commands/eventstatus.js`
+- `event_zip_v1` → `bot/commands/eventexport.js`
+- `setscan_v1` → `bot/commands/setscan.js`
+- `filter_v1` → **nicht implementiert** (Platzhalter für zukünftiges Feature)
+
+## Services & Libraries
+- `scannerClient_v1` → `bot/lib/scannerClient.js`
+- `botConfig_v1` → `bot/lib/botConfig.js`
+- `eventStore_v1` → `bot/lib/eventStore.js`
+- `flaggedStore_v1` → `bot/lib/flaggedStore.js`
+- `logger_v1` → `bot/lib/logger.js`
+- `permissions_v1` → `bot/lib/permissions.js`
+
+## Verzeichnisstruktur (Soll/Ist)
+```
+bot/
+  index.js
+  commands/
+    eventstart.js
+    eventstop.js
+    eventstatus.js
+    eventextend.js
+    eventexport.js
+    setscan.js
+    # filter_v1.js reserviert
+  config/
+    bot-config.json
+    bot-config.example.json
+  events/
+    ready.js
+    messageCreate.js
+    messageReactionAdd.js
+    messageReactionRemove.js
+  lib/
+    botConfig.js
+    scannerClient.js
+    eventStore.js
+    flaggedStore.js
+    permissions.js
+    logger.js
+    # *_v1.js Wrapper für Referenznamen
+  data/
+    events/
+    deleted/
+    logs/
+```
+
+Die `data/`-Unterordner werden zur Laufzeit erzeugt und bleiben von Git ausgeschlossen.

--- a/README.md
+++ b/README.md
@@ -17,14 +17,39 @@ Der bisherige Legacy-Code ist weiterhin unter [`_archived/`](./_archived/) verf�
 ```
 README.md
 AGENTS.md
+DOCU/
+  STRUCTURE_SYNC.md
 bot/
   package.json
   index.js
   config/
     bot-config.example.json
   commands/
+    eventstart.js
+    eventstop.js
+    eventstatus.js
+    eventextend.js
+    eventexport.js
+    setscan.js
+    # reservierter Slot: filter_v1.js
   events/
+    ready.js
+    messageCreate.js
+    messageReactionAdd.js
+    messageReactionRemove.js
   lib/
+    botConfig.js
+    botConfig_v1.js
+    scannerClient.js
+    scannerClient_v1.js
+    eventStore.js
+    eventStore_v1.js
+    flaggedStore.js
+    flaggedStore_v1.js
+    permissions.js
+    permissions_v1.js
+    logger.js
+    logger_v1.js
   data/
     events/
     deleted/
@@ -39,8 +64,9 @@ _archived/
 
 - `bot/commands/` – ein Modul pro Textbefehl (Eventstart, Export, Scan-Konfiguration usw.).
 - `bot/events/` – Discord-Eventlistener (`ready`, `messageCreate`, `messageReaction*`).
-- `bot/lib/` – Hilfsbibliotheken: Scanner-Client, Config-Lader, Event-/Flagged-Stores, Logging, Berechtigungen.
+- `bot/lib/` – Hilfsbibliotheken: Scanner-Client, Config-Lader, Event-/Flagged-Stores, Logging, Berechtigungen. Wrapper mit `_v1` spiegeln die Namenskonvention der Referenzdokumentation.
 - `bot/data/` – Arbeitsdaten des Bots (Events, Logs, gelöschte Uploads). Wird zur Laufzeit erstellt und nicht versioniert.
+- `DOCU/STRUCTURE_SYNC.md` – Verbindliche Zuordnung zwischen Referenzstruktur (`*_v1`) und produktiven Dateien.
 - `docs/` – Technische und organisatorische Dokumentation für Team und Operator:innen.
 
 ## Voraussetzungen
@@ -127,6 +153,8 @@ _archived/
 - `scanner.baseUrl`, `scanner.email`, `scanner.clientId` – Zugangsdaten zum externen Scanner.
 - Pro Guild: `modChannelId`, `logChannelId` sowie passende Rollen-IDs für Admins und Moderation.
 
+> 💡 **Kompatibilität zur Referenz-Doku:** `bot.discordToken`, `bot.ownerIds` und `scanner.url` werden automatisch auf die produktiv genutzten Felder (`bot.token`, `bot.owners`, `scanner.baseUrl`) gemappt. Fehlen `paths` oder `versions`, ergänzt der Loader Standardwerte (`./data/events`, `./data/deleted`, `./data/logs` sowie `v1`).
+
 ### Mehrere Guilds
 
 `guilds` enthält je einen Schlüssel pro Guild-ID. Nicht gesetzte Werte fallen automatisch auf `bot.defaultGuild` zurück.
@@ -151,6 +179,17 @@ _archived/
 | `!eventstatus`    | Mod          | Zeigt aktive Events des Servers an. |
 | `!eventexport`    | Admin        | Erstellt eine ZIP-Datei mit Event-Uploads. |
 | `!setscan`        | Admin        | Aktualisiert Flag-/Delete-Schwellenwerte pro Guild. |
+
+### Referenz-Mapping der Commands
+
+| Referenz (Doku) | Produktiver Command |
+|-----------------|---------------------|
+| `event_start_v1` | `!eventstart` |
+| `event_stop_v1`  | `!eventstop` |
+| `event_stats_v1` | `!eventstatus` |
+| `event_zip_v1`   | `!eventexport` |
+| `setscan_v1`     | `!setscan` |
+| `filter_v1`      | _nicht implementiert_ |
 
 ## Event- und Reaktionslogik
 

--- a/bot/lib/botConfig.js
+++ b/bot/lib/botConfig.js
@@ -2,29 +2,92 @@ const fs = require('fs');
 const path = require('path');
 
 const CONFIG_FILENAME = 'bot-config.json';
+const DEFAULT_PATHS = {
+  eventFiles: './data/events',
+  deletedFiles: './data/deleted',
+  logs: './data/logs'
+};
+const DEFAULT_VERSIONS = {
+  events: 'v1',
+  commands: 'v1',
+  scannerClient: 'v1',
+  eventStore: 'v1'
+};
 
 function resolveConfigPath() {
   return path.join(__dirname, '..', 'config', CONFIG_FILENAME);
+}
+
+function toArray(value) {
+  if (Array.isArray(value)) {
+    return value;
+  }
+  if (value === undefined || value === null) {
+    return [];
+  }
+  return [value];
+}
+
+function normalizeConfigShape(config) {
+  const normalized = { ...(config || {}) };
+
+  const bot = { ...(normalized.bot || {}) };
+  if (!bot.token && bot.discordToken) {
+    bot.token = bot.discordToken;
+  }
+  if (bot.token && !bot.discordToken) {
+    bot.discordToken = bot.token;
+  }
+  bot.prefix = bot.prefix || '!';
+
+  const ownerList = [...new Set([...toArray(bot.owners), ...toArray(bot.ownerIds)])];
+  bot.owners = ownerList;
+  bot.ownerIds = ownerList;
+
+  bot.defaultGuild = { ...(bot.defaultGuild || {}) };
+  normalized.bot = bot;
+
+  const scanner = { ...(normalized.scanner || {}) };
+  if (!scanner.baseUrl && scanner.url) {
+    scanner.baseUrl = scanner.url;
+  }
+  if (scanner.baseUrl && !scanner.url) {
+    scanner.url = scanner.baseUrl;
+  }
+  if (!scanner.clientId && scanner.email) {
+    scanner.clientId = scanner.email;
+  }
+  if (scanner.clientId && !scanner.email) {
+    scanner.email = scanner.clientId;
+  }
+  normalized.scanner = scanner;
+
+  normalized.guilds = normalized.guilds || {};
+  normalized.paths = { ...DEFAULT_PATHS, ...(normalized.paths || {}) };
+  normalized.versions = { ...DEFAULT_VERSIONS, ...(normalized.versions || {}) };
+
+  return normalized;
 }
 
 function loadConfig() {
   const configPath = resolveConfigPath();
   const raw = fs.readFileSync(configPath, 'utf-8');
   const parsed = JSON.parse(raw);
-  if (!parsed.bot || !parsed.bot.token) {
-    throw new Error('bot-config.json: Feld "bot.token" fehlt.');
+  const normalized = normalizeConfigShape(parsed);
+  if (!normalized.bot || !normalized.bot.token) {
+    throw new Error('bot-config.json: Feld "bot.token" bzw. "bot.discordToken" fehlt.');
   }
-  if (!parsed.bot.prefix) {
-    parsed.bot.prefix = '!';
-  }
-  parsed.bot.owners = Array.isArray(parsed.bot.owners) ? parsed.bot.owners : [];
-  parsed.guilds = parsed.guilds || {};
-  return parsed;
+  return normalized;
 }
 
 function saveConfig(config) {
   const configPath = resolveConfigPath();
-  fs.writeFileSync(configPath, JSON.stringify(config, null, 2));
+  const normalized = normalizeConfigShape(config);
+  if (!normalized.bot || !normalized.bot.token) {
+    throw new Error('bot-config.json: Feld "bot.token" bzw. "bot.discordToken" fehlt.');
+  }
+  fs.writeFileSync(configPath, JSON.stringify(normalized, null, 2));
+  return normalized;
 }
 
 function mergeGuildConfig(baseConfig, guildId) {

--- a/bot/lib/botConfig_v1.js
+++ b/bot/lib/botConfig_v1.js
@@ -1,0 +1,1 @@
+module.exports = require('./botConfig');

--- a/bot/lib/eventStore_v1.js
+++ b/bot/lib/eventStore_v1.js
@@ -1,0 +1,1 @@
+module.exports = require('./eventStore');

--- a/bot/lib/flaggedStore_v1.js
+++ b/bot/lib/flaggedStore_v1.js
@@ -1,0 +1,1 @@
+module.exports = require('./flaggedStore');

--- a/bot/lib/logger_v1.js
+++ b/bot/lib/logger_v1.js
@@ -1,0 +1,1 @@
+module.exports = require('./logger');

--- a/bot/lib/permissions_v1.js
+++ b/bot/lib/permissions_v1.js
@@ -1,0 +1,1 @@
+module.exports = require('./permissions');

--- a/bot/lib/scannerClient_v1.js
+++ b/bot/lib/scannerClient_v1.js
@@ -1,0 +1,1 @@
+module.exports = require('./scannerClient');


### PR DESCRIPTION
## Summary
- capture the reference-to-production mapping in DOCU/STRUCTURE_SYNC.md and surface it in README/AGENTS guidance
- normalize bot/lib/botConfig.js so reference-style fields map onto the live configuration and default paths/versions exist
- add *_v1.js wrappers that forward reference module names to their production counterparts for compatibility

## Testing
- not run (per instructions)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69170542e38883338562cdc4c6be0d03)