### PR TITLE
Fix scanner client token handling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,6 +3,7 @@
 - ✅ Neue Implementierung lebt unter [`bot/`](./bot/). Alle Änderungen für den aktiven Bot passieren dort.
 - 📁 Die Legacy-Fassung bleibt in [`_archived/`](./_archived/) und ist nur Referenz – keine Änderungen ohne ausdrückliche Aufgabe. Die historischen DOCU-Unterlagen liegen jetzt unter [`_archived/DOCU/`](./_archived/DOCU/).
 - 🧾 Dokumentation pflegen: Diese Datei sowie [`README.md`](./README.md), [`docs/README.md`](./docs/README.md) und [`docs/AGENTS.md`](./docs/AGENTS.md) sind die verbindlichen Quellen.
+- 🔄 Scanner-Client: `/token` liefert einen reinen Text-Token. Verwende ihn unverändert im `Authorization`-Header (kein `Bearer`).
 - 🧭 Referenz-Mapping (`*_v1` ↔ produktive Module) ist in [`_archived/DOCU/STRUCTURE_SYNC.md`](./_archived/DOCU/STRUCTURE_SYNC.md) dokumentiert. Die aktuelle Architektur nutzt den `moduleLoader` unter `bot/lib/moduleLoader.js` und modulare Verzeichnisse unter `bot/modules/`.
 - 🧩 Konfiguration erfolgt zweistufig: globale Defaults in `bot/config/bot-global.json`, Guild-spezifische Dateien unter `bot/config/guilds/<GUILD_ID>.json`. Der `ConfigManager` sorgt für Auto-Onboarding und Reloads – bitte keine Legacy-`bot-config.json` mehr verwenden.
 - ✉️ Direktnachrichten: Der Core routet DM-Nachrichten an `bot/lib/dmHandler.js`. Dort sind Invite-Parsing sowie Admin-Konfigurationsbefehle implementiert (`!guilds`, `!config`, `!config set`). Neue DM-Features hier integrieren.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Ein modularer Discord-Bot für die PixAI-Community. Die aktuelle Generation setz
 - **Bot-Kern**: Läuft auf Node.js (discord.js v14) im Verzeichnis [`bot/`](./bot/). Der Core initialisiert den Discord-Client, lädt Konfigurationen, Module und Health-Checks.
 - **Module**: Befinden sich unter [`bot/modules/`](./bot/modules/) und kapseln Features wie Tag-Scanning, Picture-Events und Community-Guard.
 - **Persistenz**: `lib/eventStore.js` und `lib/flaggedStore.js` speichern Event-Uploads bzw. moderierte Inhalte als JSON.
-- **Scanner-Integration**: `lib/scannerClient.js` bündelt alle HTTP-Aufrufe zum externen Scanner.
+- **Scanner-Integration**: `lib/scannerClient.js` bündelt alle HTTP-Aufrufe zum externen Scanner. Der Client erwartet einen reinen Text-Token vom Endpunkt `/token` und sendet ihn unverändert (ohne `Bearer`-Präfix) im `Authorization`-Header.
 
 ## Kanonische Dokumentation
 

--- a/bot/lib/scannerClient.js
+++ b/bot/lib/scannerClient.js
@@ -31,16 +31,20 @@ module.exports = function createScannerClient(scannerConfig = {}, logger) {
 
   async function ensureToken({ renew = false } = {}) {
     if (disabled) return null;
+
     if (!scannerConfig.email || !scannerConfig.clientId) {
       throw new Error('Scanner-Konfiguration ist unvollständig (email/clientId).');
     }
+
     const now = Date.now();
     if (!renew && token && tokenExpiresAt - 60_000 > now) {
       return token;
     }
+
     while (isRenewing) {
       await delay(100);
     }
+
     isRenewing = true;
     try {
       const url = buildUrl(scannerConfig.baseUrl, 'token', {
@@ -48,19 +52,44 @@ module.exports = function createScannerClient(scannerConfig = {}, logger) {
         clientId: scannerConfig.clientId,
         renew: renew ? '1' : undefined
       });
+
       const res = await fetch(url, {
         method: 'GET',
-        headers: { Accept: 'application/json' },
+        headers: { Accept: 'application/json,text/plain;q=0.9,*/*;q=0.8' },
         signal: AbortSignal.timeout(scannerConfig.timeoutMs || 10000)
       });
+
       if (!res.ok) {
-        const text = await res.text();
+        const text = await res.text().catch(() => '');
         throw new Error(`Tokenabruf fehlgeschlagen (${res.status}): ${text}`);
       }
-      const body = await res.json();
-      token = body.token;
-      const ttl = Number(body.expiresIn || body.expires_in || 600);
-      tokenExpiresAt = Date.now() + ttl * 1000;
+
+      const raw = await res.text();
+      let parsed = null;
+      let newToken = null;
+
+      // Versuch JSON → Fallback auf reinen Text
+      try {
+        parsed = JSON.parse(raw);
+      } catch {
+        parsed = null;
+      }
+
+      if (parsed && typeof parsed === 'object' && parsed.token) {
+        newToken = String(parsed.token);
+        const ttl = Number(parsed.expiresIn || parsed.expires_in || 600);
+        tokenExpiresAt = Date.now() + ttl * 1000;
+      } else {
+        newToken = String(raw).trim();
+        const ttl = 600; // 10 Minuten Fallback
+        tokenExpiresAt = Date.now() + ttl * 1000;
+      }
+
+      if (!newToken) {
+        throw new Error(`Kein Token in Antwort von /token: "${raw}"`);
+      }
+
+      token = newToken;
       clientLogger?.info('Scanner-Token erneuert');
       return token;
     } finally {
@@ -72,23 +101,29 @@ module.exports = function createScannerClient(scannerConfig = {}, logger) {
     if (disabled) {
       return { ok: false, disabled: true, data: null };
     }
+
     try {
       const authToken = await ensureToken({ renew: attempt > 0 });
       const url = buildUrl(scannerConfig.baseUrl, pathname);
+
       const headers = {
         ...(options.headers || {}),
-        Authorization: authToken ? `Bearer ${authToken}` : undefined
+        // Scanner erwartet den Token direkt, ohne "Bearer "
+        Authorization: authToken || undefined
       };
+
       const response = await fetch(url, {
         ...options,
         headers,
         signal: AbortSignal.timeout(scannerConfig.timeoutMs || 15000)
       });
+
       if (response.status === 403 && attempt === 0) {
         clientLogger?.warn('Scanner antwortete mit 403 – versuche Token zu erneuern');
         await ensureToken({ renew: true });
         return perform(pathname, options, 1);
       }
+
       const text = await response.text();
       const data = toJSONSafe(text);
       return { ok: response.ok, status: response.status, data };
@@ -104,10 +139,12 @@ module.exports = function createScannerClient(scannerConfig = {}, logger) {
       const formData = new FormData();
       const blob = new Blob([buffer], { type: mimeType || 'application/octet-stream' });
       formData.append('file', blob, filename || 'upload');
+
       const result = await perform('check', {
         method: 'POST',
         body: formData
       });
+
       return result;
     } catch (error) {
       clientLogger?.error('scanImage fehlgeschlagen', { error: error.message });


### PR DESCRIPTION
## Summary
- update the scanner client to accept plain text tokens and send the token directly in the Authorization header
- add resilient fallback parsing and TTL handling when renewing tokens from /token
- document the scanner client expectations in the repository guides

## Testing
- not run (per instructions)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69185097aacc8333a3606feb9af3d886)