### PR TITLE
Fix scanner downloads and add scanner API reference docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 - ✅ Neue Implementierung lebt unter [`bot/`](./bot/). Alle Änderungen für den aktiven Bot passieren dort.
 - 📁 Die Legacy-Fassung bleibt in [`_archived/`](./_archived/) und ist nur Referenz – keine Änderungen ohne ausdrückliche Aufgabe. Die historischen DOCU-Unterlagen liegen jetzt unter [`_archived/DOCU/`](./_archived/DOCU/).
-- 🧾 Dokumentation pflegen: Diese Datei sowie [`README.md`](./README.md), [`docs/README.md`](./docs/README.md) und [`docs/AGENTS.md`](./docs/AGENTS.md) sind die verbindlichen Quellen.
+- 🧾 Dokumentation pflegen: Diese Datei sowie [`README.md`](./README.md), [`docs/README.md`](./docs/README.md) und [`docs/AGENTS.md`](./docs/AGENTS.md) sind die verbindlichen Quellen. Ergänzende Referenzen (z. B. Scanner-API-Spezifikationen) liegen unter [`docs/scanner-api-reference/`](./docs/scanner-api-reference/) und gehören **nicht** zum produktiven Bot-Code.
 - 🔄 Scanner-Client: `/token` liefert einen reinen Text-Token. Verwende ihn unverändert im `Authorization`-Header (kein `Bearer`). Der Client in `bot/lib/scannerClient.js` übernimmt Downloads & Multipart-Aufbau – nutze dort `checkImageFromUrl` für Einzelbilder bzw. `batchFromUrl` für GIF/Video-Uploads.
 - 📦 Der Scanner-Client nutzt ausschließlich die in Node.js 18+ enthaltenen Implementierungen von `fetch`, `FormData`, `File` und `Blob`. Zusätzliche HTTP- oder Multipart-Pakete sind nicht erforderlich.
 - 📦 Der aktive Code bleibt bei CommonJS (`require`). Besonders `bot/lib/scannerClient.js` exportiert einen Factory-Wrapper; bitte keine ES-Module-Imports im aktiven Bot ergänzen.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Ein modularer Discord-Bot für die PixAI-Community. Die aktuelle Generation setz
 - **Bot-Kern**: Läuft auf Node.js (discord.js v14) im Verzeichnis [`bot/`](./bot/). Der Core initialisiert den Discord-Client, lädt Konfigurationen, Module und Health-Checks.
 - **Module**: Befinden sich unter [`bot/modules/`](./bot/modules/) und kapseln Features wie Tag-Scanning, Picture-Events, Community-Guard und den NSFW-Scanner.
 - **Persistenz**: `lib/eventStore.js` und `lib/flaggedStore.js` speichern Event-Uploads bzw. moderierte Inhalte als JSON.
-- **Scanner-Integration**: `lib/scannerClient.js` bündelt alle HTTP-Aufrufe zum externen Scanner. Der Client erwartet einen reinen Text-Token vom Endpunkt `/token` und sendet ihn unverändert (ohne `Bearer`-Präfix) im `Authorization`-Header. Seit dem neuen Upload-Flow erledigt der Client auch das Herunterladen von Medien (Discord-CDN, externe Links) und baut korrekte `multipart/form-data`-Uploads über die Hilfsfunktionen `checkImageFromUrl` (Einzelbilder) sowie `batchFromUrl` (GIF/Video). Technisch kommt dafür ausschließlich die in Node.js integrierte `fetch`-Implementierung inklusive `FormData`, `File` und `Blob` zum Einsatz. Der Code bleibt dabei vollständig im CommonJS-Stil (`require`), sodass keine `type: "module"`-Umstellung nötig ist.
+- **Scanner-Integration**: `lib/scannerClient.js` bündelt alle HTTP-Aufrufe zum externen Scanner. Der Client erwartet einen reinen Text-Token vom Endpunkt `/token` und sendet ihn unverändert (ohne `Bearer`-Präfix) im `Authorization`-Header. Seit dem neuen Upload-Flow erledigt der Client auch das Herunterladen von Medien (Discord-CDN, externe Links) und baut korrekte `multipart/form-data`-Uploads über die Hilfsfunktionen `checkImageFromUrl` (Einzelbilder) sowie `batchFromUrl` (GIF/Video). Für Downloads verwenden wir bewusst das Node.js-`https`-Modul, um Timeout- und Stream-Handling stabil zu halten; für die Uploads kommen die nativen Implementierungen von `fetch`, `FormData`, `File` und `Blob` zum Einsatz. Der Code bleibt dabei vollständig im CommonJS-Stil (`require`), sodass keine `type: "module"`-Umstellung nötig ist.
 
 ## Phase-2 Scanner (BOT1)
 
@@ -41,6 +41,7 @@ Die folgenden Dokumente sind die Referenz für Architektur, Prozesse und Rollen:
 - [`docs/README.md`](./docs/README.md) – Detailarchitektur, Flows und Betriebsleitfäden.
 - [`docs/AGENTS.md`](./docs/AGENTS.md) – Rollen- und Verantwortlichkeitsmatrix.
 - [`AGENTS.md`](./AGENTS.md) – Arbeitsrichtlinien für dieses Repository.
+- [`docs/scanner-api-reference/`](./docs/scanner-api-reference/) – Ablage für externe Scanner-API-Referenzen (kein produktiver Code).
 
 Historische Unterlagen liegen unter [`_archived/`](./_archived/) und dienen nur als Referenz.
 

--- a/docs/scanner-api-reference/README.md
+++ b/docs/scanner-api-reference/README.md
@@ -1,0 +1,5 @@
+# Scanner API Referenzablage
+
+Dieser Ordner dient ausschließlich als Ablage für Referenzmaterial zur externen Scanner-API (z. B. Beispiel-Responses, Schema-Dateien oder Endpoint-Beschreibungen). Die Inhalte gehören nicht zum produktiven Bot-Code und werden nur zur Dokumentation oder Analyse genutzt.
+
+Bitte füge hier keine lauffähigen Services oder vertraulichen Zugangsdaten ein. Wenn neue Dateien ergänzt werden, verlinke sie bei Bedarf in der Projekt-README oder den Entwicklerdokumenten, damit klar bleibt, dass es sich um reine Referenzdaten handelt.


### PR DESCRIPTION
## Summary
- replace the fetch-based download helper in `scannerClient` with a resilient `https` stream implementation so media checks reach the external scanner again
- document the change in the main README and point to the new scanner API reference directory in the contributor guidelines
- add a dedicated `docs/scanner-api-reference` folder as a drop-in location for external scanner API reference material

## Testing
- not run (per instructions)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691887cee3188333a74321fc72d29d08)